### PR TITLE
Remove deprecated calling hash as reference

### DIFF
--- a/bin/lib/NConf/ExportNagios.pm
+++ b/bin/lib/NConf/ExportNagios.pm
@@ -1292,9 +1292,9 @@ $fattr,$fval
 
                                     # write any other default service dependency params (e.g "notification_failure_criteria" etc)
                                     foreach my $def_srv_deps_param (keys(%{$srv->[2]})){
-                                        unless($def_srv_deps_param && %{$srv->[2]}->{$def_srv_deps_param}){next}
+                                        unless($def_srv_deps_param && ${$srv->[2]}{$def_srv_deps_param}){next}
                                         $fattr = $def_srv_deps_param;
-                                        $fval  = %{$srv->[2]}->{$def_srv_deps_param};
+                                        $fval  = ${$srv->[2]}{$def_srv_deps_param};
                                         write FILE;
                                     }
                                     print FILE "}\n\n";


### PR DESCRIPTION
In Perl 5.22 and newer is deprecated call has as reference, this code %hash->{$key} must be replaced by $hash{$key}